### PR TITLE
Fix crasher on isinstance(some_obj, Exception)

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1219,6 +1219,8 @@ class BuiltinObjectType(PyObjectType):
             type_check = 'PyByteArray_Check'
         elif type_name == 'frozenset':
             type_check = 'PyFrozenSet_Check'
+        elif type_name == 'Exception':
+            type_check = 'PyExceptionClass_Check'
         else:
             type_check = 'Py%s_Check' % type_name.capitalize()
         if exact and type_name not in ('bool', 'slice', 'Exception'):


### PR DESCRIPTION
isinstance("", Exception)

..causes Cython to generate a call to PyException_Check() which does not exist.  I think the correct call is PyExceptionClass_Check().